### PR TITLE
Fix - Traefik reverse proxy

### DIFF
--- a/pi-5/docker-compose-reverse-proxy.yaml
+++ b/pi-5/docker-compose-reverse-proxy.yaml
@@ -16,11 +16,6 @@ services:
       homelab_vlan:
         ipv4_address: 192.168.1.203
       homelab:
-      # ports:
-      # - 80:80
-      # - 443:443
-      # - 443:443/tcp # Uncomment if you want HTTP3
-      # - 443:443/udp # Uncomment if you want HTTP3
     environment:
       CF_DNS_API_TOKEN: ${TRAEFIK_CLOUDFLARED_TOKEN}
       TRAEFIK_DASHBOARD_CREDENTIALS: ${TRAEFIK_DASHBOARD_CREDENTIALS}
@@ -32,6 +27,7 @@ services:
       - ./traefik/config.yml:/config.yml:ro
     labels:
       - "traefik.enable=true"
+      - "traefik.port=80"
       - "traefik.http.routers.traefik.entrypoints=http"
       - "traefik.http.routers.traefik.rule=Host(`traefik.local.${DOMAIN_NAME}`)"
       - "traefik.http.middlewares.traefik-auth.basicauth.users=${TRAEFIK_DASHBOARD_CREDENTIALS}"


### PR DESCRIPTION
This pull request makes a small update to the `pi-5/docker-compose-reverse-proxy.yaml` file for the reverse proxy service configuration. The main change is the addition of the `traefik.port=80` label to clarify which port Traefik should use, and some commented-out port mappings have been removed for clarity.

**Reverse proxy configuration improvements:**

* Added the `traefik.port=80` label to the Traefik service to explicitly specify the port Traefik should use.
* Removed commented-out port mappings for ports 80 and 443 in the `homelab` service section to clean up the configuration.