### PR TITLE
SearXNG

### DIFF
--- a/docker-compose-pi-5.yaml
+++ b/docker-compose-pi-5.yaml
@@ -7,13 +7,15 @@ networks:
 include:
   - common/docker-compose-unbound.yaml
   - pi-5/docker-compose-ad-blocker.yaml
-  - pi-5/docker-compose-ai-automation.yaml
   - pi-5/docker-compose-arr.yaml
-  - pi-5/docker-compose-auth.yaml
   - pi-5/docker-compose-monitoring.yaml
   - pi-5/docker-compose-utils.yaml
   - pi-5/docker-compose-reverse-proxy.yaml
   - pi-5/docker-compose-immich.yaml
+  - pi-5/docker-compose-searx.yaml
+  # - pi-5/docker-compose-office.yaml
+  # - pi-5/docker-compose-ai-automation.yaml
+  # - pi-5/docker-compose-auth.yaml
 
 services:
   homepage:
@@ -32,6 +34,7 @@ services:
       - ${SERVICES_ROOT}/homepage/config:/app/config:rw
       - /mnt/Movies:/mnt/Movies:ro
       - /mnt/Series:/mnt/Series:ro
+      - /mnt/Immich:/mnt/Immich:ro
     expose:
       - 80
     networks:

--- a/pi-5/docker-compose-searx.yaml
+++ b/pi-5/docker-compose-searx.yaml
@@ -1,0 +1,57 @@
+networks:
+  homelab_vlan:
+    external: true
+  homelab:
+    external: true
+  homelab_dns:
+    external: true
+
+volumes:
+  valkey-cache:
+  searxng-cache:
+
+services:
+  redis:
+    container_name: redis
+    image: docker.io/valkey/valkey:8-alpine
+    command: valkey-server --save 30 1 --loglevel warning
+    restart: unless-stopped
+    networks:
+      - homelab
+    volumes:
+      - valkey-cache:/data
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1m"
+        max-file: "1"
+
+  searxng:
+    container_name: searxng
+    image: docker.io/searxng/searxng:latest
+    restart: unless-stopped
+    networks:
+      - homelab
+      - homelab_dns
+    dns:
+      - 172.20.0.5
+    expose:
+      - 8080
+    volumes:
+      - ${SERVICES_ROOT}/searxng:/etc/searxng:rw
+      - searxng-cache:/var/cache/searxng:rw
+    environment:
+      SEARXNG_BASE_URL: https://searx.local.${DOMAIN_NAME}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1m"
+        max-file: "1"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.searx.rule=Host(`searx.local.${DOMAIN_NAME}`)"
+      - "traefik.http.routers.searx.entrypoints=http"
+      - "traefik.http.routers.searx-secure.rule=Host(`searx.local.${DOMAIN_NAME}`)"
+      - "traefik.http.routers.searx-secure.entrypoints=https"
+      - "traefik.http.routers.searx-secure.tls.certresolver=cloudflare"
+      - "traefik.http.services.searx-secure.loadbalancer.server.port=8080"


### PR DESCRIPTION
This pull request updates the Docker Compose setup for the pi-5 environment by adding a new SearxNG search engine service, adjusting service includes, and updating volume mounts for the homepage service. The main focus is on introducing SearxNG and its dependencies, while some previously included services are now commented out.

**New SearxNG Service Addition:**

* Added a new `pi-5/docker-compose-searx.yaml` file to define the SearxNG search engine and its Redis (Valkey) dependency, including network configuration, volumes, environment variables, and Traefik labels for reverse proxy integration.
* Included `pi-5/docker-compose-searx.yaml` in the main `docker-compose-pi-5.yaml` file to enable the new search engine service.

**Service Configuration Updates:**

* Updated the `homepage` service to mount `/mnt/Immich` as a read-only volume, providing access to Immich data.

**Service Includes Cleanup:**

* Commented out the includes for `pi-5/docker-compose-ai-automation.yaml`, `pi-5/docker-compose-auth.yaml`, and `pi-5/docker-compose-office.yaml` in `docker-compose-pi-5.yaml`, effectively disabling these services for now.