### PR TITLE
Fix - Traefik configuration/acme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository contains the configuration files and scripts for my Raspberry Pi
 
 ## Installation
 
+### Prerequisites
+
 Install the required packages:
 
 ```bash
@@ -11,7 +13,11 @@ chmod +x install.sh
 sh install.sh
 ```
 
-Wait for the Raspberry Pi to reboot. Then, create the required networks for docker:
+Wait for the Raspberry Pi to reboot. 
+
+### Network Configuration
+
+Then, create the required networks for docker:
 
 ```bash
 docker network create -d macvlan \
@@ -35,7 +41,16 @@ docker network create -d bridge \
   homelab
 ```
 
-Finally, clone this repository to the Raspberry Pi.
+### Reverse Proxy Configuration
+
+Copy the `pi-5/traefik/` folder to `${SERVICES_ROOT}/traefik/`, as follows:
+
+```bash
+mkdir -p ${SERVICES_ROOT}/traefik/
+cp -r pi-5/traefik/* ${SERVICES_ROOT}/traefik/
+```
+
+Then, modify the `traefik.yml` file to set the correct `email` and `domain name` values.
 
 ## Secrets
 

--- a/pi-5/docker-compose-reverse-proxy.yaml
+++ b/pi-5/docker-compose-reverse-proxy.yaml
@@ -22,9 +22,9 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./traefik/traefik.yml:/traefik.yml:ro
-      - ./traefik/acme.json:/acme.json
-      - ./traefik/config.yml:/config.yml:ro
+      - ${SERVICES_ROOT}/traefik/traefik.yml:/traefik.yml:ro
+      - ${SERVICES_ROOT}/traefik/acme.json:/acme.json
+      - ${SERVICES_ROOT}/traefik/config.yml:/config.yml:ro
     labels:
       - "traefik.enable=true"
       - "traefik.port=80"


### PR DESCRIPTION
This pull request updates the setup instructions and configuration for the reverse proxy service, making the process more modular and configurable. The most important changes are:

**Documentation improvements:**

* The `README.md` now includes clearer sections for prerequisites, network configuration, and reverse proxy configuration, making the setup steps easier to follow.
* Added instructions to copy the `pi-5/traefik/` folder to a configurable `${SERVICES_ROOT}/traefik/` directory, and to update `traefik.yml` with the correct email and domain name.

**Configuration changes:**

* Updated `pi-5/docker-compose-reverse-proxy.yaml` to mount Traefik configuration files from `${SERVICES_ROOT}/traefik/` instead of a relative path, allowing for more flexible and centralized configuration management.