### PR TITLE
Office

### DIFF
--- a/pi-5/docker-compose-office.yaml
+++ b/pi-5/docker-compose-office.yaml
@@ -1,0 +1,34 @@
+networks:
+  homelab_vlan:
+    external: true
+  homelab:
+    external: true
+
+services:
+  libreoffice:
+    container_name: libreoffice
+    image: lscr.io/linuxserver/libreoffice:latest
+    restart: unless-stopped
+    hostname: libreoffice
+    security_opt:
+      - seccomp:unconfined #optional
+    expose:
+      - 3000
+      - 3001
+    shm_size: "1gb"
+    environment:
+      PUID: ${PUID}
+      PGID: ${PGID}
+      TZ: ${TZ}
+    volumes:
+      - ${SERVICES_ROOT}/libreoffice/config:/config
+    networks:
+      - homelab
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.libreoffice.rule=Host(`libreoffice.local.${DOMAIN_NAME}`)"
+      - "traefik.http.routers.libreoffice.entrypoints=http"
+      - "traefik.http.routers.libreoffice-secure.rule=Host(`libreoffice.local.${DOMAIN_NAME}`)"
+      - "traefik.http.routers.libreoffice-secure.entrypoints=https"
+      - "traefik.http.routers.libreoffice-secure.tls.certresolver=cloudflare"
+      - "traefik.http.services.libreoffice-secure.loadbalancer.server.port=3000"


### PR DESCRIPTION
This pull request adds a new Docker Compose configuration for running a LibreOffice service in the `pi-5/docker-compose-office.yaml` file. The configuration sets up the LibreOffice container with appropriate networking, environment variables, volumes, and Traefik reverse proxy labels for routing.

New LibreOffice service setup:

* Added a `libreoffice` service using the `lscr.io/linuxserver/libreoffice:latest` image, with environment variables, persistent configuration volume, and network assignments to `homelab` and `homelab_vlan`.
* Configured Traefik labels for HTTP and HTTPS routing, including rules for secure access and certificate resolution.